### PR TITLE
Тэг currency закрывается по особым правилам

### DIFF
--- a/src/models/Currency.php
+++ b/src/models/Currency.php
@@ -79,4 +79,25 @@ class Currency extends BaseModel
     {
         return null;
     }
+    
+    /**
+     * @return string
+     */
+    protected function getYmlEndTag()
+    {
+        return '';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getYmlStartTag()
+    {
+        $string = '';
+        if (static::$tag) {
+            $string = '<' . static::$tag . $this->getYmlTagProperties() . ' />';
+        }
+
+        return $string;
+    }
 }


### PR DESCRIPTION
Должно быть так: `<currency id="RUB" rate="CBRF" plus="0" />`
Если закрывать тэг `currency` (по общим правилам pastuhov\ymlcatalog\models\BaseModel), то при проверке валидатором [shops.dtd](https://yandex.st/market-export/1.0-17/partner/help/shops.dtd) есть предупреждения.
