### PR TITLE
Валидация свойства delivery

### DIFF
--- a/src/models/SimpleOffer.php
+++ b/src/models/SimpleOffer.php
@@ -97,17 +97,12 @@ class SimpleOffer extends BaseModel
                 'max' => 120,
             ],
             [
-                ['delivery'],
+                ['delivery', 'pickup'],
                 'in',
                 'range' => [
                     'true',
                     'false'
                 ]
-            ],
-            [
-                ['pickup'],
-                'string',
-                'max' => 4,
             ],
             [
                 ['id', 'categoryId', 'bid', 'cbid'],

--- a/src/models/SimpleOffer.php
+++ b/src/models/SimpleOffer.php
@@ -97,7 +97,15 @@ class SimpleOffer extends BaseModel
                 'max' => 120,
             ],
             [
-                ['delivery', 'pickup'],
+                ['delivery'],
+                'in',
+                'range' => [
+                    'true',
+                    'false'
+                ]
+            ],
+            [
+                ['pickup'],
                 'string',
                 'max' => 4,
             ],


### PR DESCRIPTION
В случае [Товар не доставляется, доступен только самовывоз](https://yandex.ru/support/partnermarket/elements/delivery-options.xml#example7) свойство delivery может быть как `false`, так и `true`
